### PR TITLE
CombinedReducer.reduce: added instance check

### DIFF
--- a/suas-lib/src/main/java/zendesk/suas/CombinedReducer.java
+++ b/suas-lib/src/main/java/zendesk/suas/CombinedReducer.java
@@ -54,7 +54,9 @@ class CombinedReducer {
             @SuppressWarnings("unchecked") final Object newStateForKey = reducer.reduce(oldStateForKey, action);
             if(newStateForKey != null) {
                 state.updateKey(reducer.getStateKey(), newStateForKey);
-                updatedKeys.add(reducer.getStateKey());
+                if (newStateForKey != oldStateForKey) {
+                    updatedKeys.add(reducer.getStateKey());
+                }
             } else {
                 state.updateKey(reducer.getStateKey(), oldStateForKey);
             }

--- a/suas-lib/src/test/java/zendesk/suas/CombinedReducerTest.kt
+++ b/suas-lib/src/test/java/zendesk/suas/CombinedReducerTest.kt
@@ -50,7 +50,7 @@ class CombinedReducerTest {
     }
 
     @Test
-    fun `reduce - no changes`() {
+    fun `reduce - no changes null`() {
         val r1 = TestReducer("1", null)
         val r2 = TestReducer("2", "new_state_2")
         val r3 = TestReducer("3", null)
@@ -61,6 +61,24 @@ class CombinedReducerTest {
         assertThat(newState.newState.getState("1")).isEqualTo(r1.initialState)
         assertThat(newState.newState.getState("2")).isEqualTo(r2.newState)
         assertThat(newState.newState.getState("3")).isEqualTo(r3.initialState)
+        assertThat(newState.updatedKeys).hasSize(1)
+        assertThat(newState.updatedKeys).contains("2")
+    }
+
+    @Test
+    fun `reduce - no changes same instance`() {
+        val initState1 = "init_state_1"
+        val initState3 = "init_state_3"
+        val r1 = TestReducerOldState("1", initState1)
+        val r2 = TestReducer("2", "new_state_2")
+        val r3 = TestReducerOldState("3", initState3)
+        val cr = CombinedReducer(listOf(r1, r2, r3))
+
+        val newState = cr.reduce(cr.emptyState, Action<Unit>("bla"))
+
+        assertThat(newState.newState.getState("1")).isSameAs(initState1)
+        assertThat(newState.newState.getState("2")).isEqualTo(r2.newState)
+        assertThat(newState.newState.getState("3")).isSameAs(initState3)
         assertThat(newState.updatedKeys).hasSize(1)
         assertThat(newState.updatedKeys).contains("2")
     }
@@ -86,4 +104,20 @@ class CombinedReducerTest {
 
         override fun getStateKey(): String = myKey
     }
+
+    /**
+     * This test reducer will always return the initial state
+     */
+    private class TestReducerOldState(val myKey: String, val initState : String) : Reducer<String>() {
+        override fun reduce(oldState: String, action: Action<*>): String? {
+            return oldState
+        }
+
+        override fun getInitialState(): String {
+            return initState
+        }
+
+        override fun getStateKey(): String = myKey
+    }
+
 }


### PR DESCRIPTION
 returning the oldState instance is now the same as returning null (no change)

reference: see this gitter chat: https://gitter.im/SuasArch/Lobby?at=5b0427e4b84be71db9287c8a